### PR TITLE
Fix for changed "sponsor issue" link on the freedomsponsors.org site

### DIFF
--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -10,7 +10,7 @@
     <label>Sponsor this issue!</label>
     <tooltip>Sponsors the issue at FreedomSponsors.org</tooltip>
 	<context-provider class="org.freedomsponsors.plugins.jira.SponsorThis"/>
-    <link linkId="manage-project-link" absolute="true">http://www.freedomsponsors.org/core/issue/sponsor?trackerURL=${baseUrl}/browse/${issue.key}</link>
+    <link linkId="manage-project-link" absolute="true">http://www.freedomsponsors.org/issue/sponsor?trackerURL=${baseUrl}/browse/${issue.key}</link>
   </web-item>
   <resource type="i18n" name="i18n" location="org.freedomsponsors.plugins.jira"/>
   <web-panel name="SponsorThis" i18n-name-key="sponsor-this.name" key="sponsor-this" location="atl.jira.view.issue.right.context" weight="1000">

--- a/src/main/resources/sponsorthis.vm
+++ b/src/main/resources/sponsorthis.vm
@@ -1,7 +1,7 @@
 #if( ${visible} )
 <p>
 	<a style="font-weight: bold; color: green;" 
-	href="http://www.freedomsponsors.org/core/issue/sponsor?trackerURL=${baseUrl}/browse/${issueKey}"
+	href="http://www.freedomsponsors.org/issue/sponsor?trackerURL=${baseUrl}/browse/${issueKey}"
 	target="_fs">
 	Sponsor $issueKey on FreedomSponsors.org</a>
 </p>


### PR DESCRIPTION
* "/core/" was removed and "page not found" error was being displayed.
  * See https://github.com/freedomsponsors/www.freedomsponsors.org/commit/53ae7a4019fbac5974e06335ae88611ed3b93c0d#commitcomment-24459613